### PR TITLE
Remove hive metastore related ASGs from chaos monkey

### DIFF
--- a/src/main/resources/chaos.properties
+++ b/src/main/resources/chaos.properties
@@ -64,6 +64,9 @@ simianarmy.chaos.ASG.pypi.enabled = false
 simianarmy.chaos.ASG.artifactory.enabled = false
 simianarmy.chaos.ASG.nfs-service.enabled = false
 simianarmy.chaos.ASG.shiny.enabled = false
+# Hive metastore related:
+simianarmy.chaos.ASG.core-hive-metastore.enabled = false
+simianarmy.chaos.ASG.legacy-hive-mss.enabled = false
 
 # increase or decrease the termination limit for a specific ASG
 # simianarmy.chaos.ASG.<asgName>.maxTerminationsPerDay = 1.0

--- a/src/main/resources/chaos.properties
+++ b/src/main/resources/chaos.properties
@@ -2,6 +2,10 @@
 # see documentation at:
 # https://github.com/Netflix/SimianArmy/wiki/Configuration
 
+# NOTE
+# This file is *not* used by the production chaos-monkey service - the
+# production spec lives in the sf-chaos-monkey service spec
+
 # let chaos run
 simianarmy.chaos.enabled = true
 
@@ -45,28 +49,11 @@ simianarmy.chaos.filldisk.enabled = false
 simianarmy.chaos.burnmoney = false
 
 
-# enable a specific ASG
-simianarmy.chaos.ASG.genie.enabled = false
-# lets kill looker asap...only excluded because I'm too lazy to properly rpm/aminate it
-simianarmy.chaos.ASG.looker.enabled = false
-simianarmy.chaos.ASG.chaos.enabled = false
-simianarmy.chaos.ASG.flotilla.enabled = false
-simianarmy.chaos.ASG.spinnaker.enabled = false
-simianarmy.chaos.ASG.vpn.enabled = false
-simianarmy.chaos.ASG.cleanroom.enabled = false
-simianarmy.chaos.ASG.helenus.enabled = false
-# Logging related service.
-simianarmy.chaos.ASG.bolt.enabled = false
-simianarmy.chaos.ASG.ow.enabled = false
-# prevent actual downtime for users, disable nexus and pypi
-simianarmy.chaos.ASG.nexus.enabled = false
-simianarmy.chaos.ASG.pypi.enabled = false
-simianarmy.chaos.ASG.artifactory.enabled = false
-simianarmy.chaos.ASG.nfs-service.enabled = false
-simianarmy.chaos.ASG.shiny.enabled = false
-# Hive metastore related:
-simianarmy.chaos.ASG.core-hive-metastore.enabled = false
-simianarmy.chaos.ASG.legacy-hive-mss.enabled = false
+# the code to disable a specific ASG would go here, but
+# this file is *not* used by the production chaos-monkey service - the
+# production spec lives in the sf-chaos-monkey service spec
+simianarmy.chaos.ASG.this-line-has-no-effect-in-production.enabled = false
+
 
 # increase or decrease the termination limit for a specific ASG
 # simianarmy.chaos.ASG.<asgName>.maxTerminationsPerDay = 1.0


### PR DESCRIPTION
Using the revised ASGs with separate Thrift and REST services.  
NOTE: this requires PR#1 to be merged to handle services with multiple dashes like core-hive-metastore